### PR TITLE
Images are shown in run-war and war targets

### DIFF
--- a/grails-app/views/_menu/_language.gsp
+++ b/grails-app/views/_menu/_language.gsp
@@ -20,7 +20,7 @@
 			<g:set var="allLocales" value="${grailsApplication.config.grails.i18n.locales}"/>
 			<g:each status="i" var="locale" in="${allLocales}">
 				<li><a class="js-language-link" title="${message(code: 'language.'+locale, default: locale)}" data-lang-code="${locale}" href="${currentURL+'?lang='+locale}">
-					<img class="" src="${resource(dir: 'images/flags',file: locale+'.png')}"/>
+					<img class="" src="${resource(plugin: 'kickstart-with-bootstrap', dir: 'images/flags',file: locale+'.png')}"/>
 					<g:message code="language.${locale}" default="${locale}"/>
 				</a></li>
 			</g:each>

--- a/grails-app/views/_menu/_navbar.gsp
+++ b/grails-app/views/_menu/_navbar.gsp
@@ -9,7 +9,7 @@
 			</a>
 
 			<a class="brand" href="${createLink(uri: '/')}">
-				<img class="logo" src="${resource(dir:'kickstart/img',file:'grails.png')}" alt="${meta(name:'app.name')}" />
+				<img class="logo" src="${resource(plugin: 'kickstart-with-bootstrap', dir:'kickstart/img',file:'grails.png')}" alt="${meta(name:'app.name')}" />
 				${meta(name:'app.name')}
 				<small> v${meta(name:'app.version')}</small>
 			</a>

--- a/grails-app/views/home/index.gsp
+++ b/grails-app/views/home/index.gsp
@@ -30,7 +30,7 @@
 		<div class="row-fluid">
 	    	<div class="span4">
 		    	<div class="center">
-					<img class="frontpageImage" src="${resource(dir: 'images/frontpage',file: 'bs-docs-twitter-github.png')}" />
+					<img class="frontpageImage" src="${resource(plugin: 'kickstart-with-bootstrap', dir: 'images/frontpage',file: 'bs-docs-twitter-github.png')}" />
 					<h3>Bootstrap 2.1.1</h3>
 				</div>
 				<p>Kickstart uses <a href ="http://twitter.github.com/bootstrap/">Bootstrap</a> to render the web pages. 
@@ -40,14 +40,14 @@
 			</div>
 	    	<div class="span4">
 		    	<div class="center">
-					<img class="frontpageImage" src="${resource(dir: 'images/frontpage',file: 'browser_logos.png')}" />
+					<img class="frontpageImage" src="${resource(plugin: 'kickstart-with-bootstrap', dir: 'images/frontpage',file: 'browser_logos.png')}" />
 					<h3>Browser support</h3>
 				</div>
 				<p>Bootstrap is tested and supported in major modern browsers like Chrome 14, Safari 5+, Opera 11, Internet Explorer 7, and Firefox 5.</p>
 			</div>
 	    	<div class="span4">
 		    	<div class="center">
-					<img class="frontpageImage" src="${resource(dir: 'images/frontpage',file: 'html5css3js8.png')}"/>
+					<img class="frontpageImage" src="${resource(plugin: 'kickstart-with-bootstrap', dir: 'images/frontpage',file: 'html5css3js8.png')}"/>
 					<h3>Tech Foundation</h3>
 				</div>
 				<p>Bootstrap is based on elements of HTML 5, CSS 3, Javascript 1.8, and jQuery 1.7 with progressively enhanced 


### PR DESCRIPTION
Added "plugin: 'kickstart-with-bootstrap', " to resource calls in <img> tags.
