### PR TITLE
Reworking how spring resources are processed. Upgrade to use lesscss-resources plugin 1.3.3

### DIFF
--- a/KickstartWithBootstrapGrailsPlugin.groovy
+++ b/KickstartWithBootstrapGrailsPlugin.groovy
@@ -2,7 +2,7 @@ import com.joergrech.kickstartwithbootstrap.CustomDateEditorRegistrar
 
 class KickstartWithBootstrapGrailsPlugin {
     // the plugin version
-    def version = "0.9.7-csherstan"
+    def version = "0.9.7b-csherstan"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "2.0 > *"
     // the other plugins this plugin depends on

--- a/KickstartWithBootstrapGrailsPlugin.groovy
+++ b/KickstartWithBootstrapGrailsPlugin.groovy
@@ -2,7 +2,7 @@ import com.joergrech.kickstartwithbootstrap.CustomDateEditorRegistrar
 
 class KickstartWithBootstrapGrailsPlugin {
     // the plugin version
-    def version = "0.9.6"
+    def version = "0.9.7-csherstan"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "2.0 > *"
     // the other plugins this plugin depends on

--- a/KickstartWithBootstrapGrailsPlugin.groovy
+++ b/KickstartWithBootstrapGrailsPlugin.groovy
@@ -1,7 +1,4 @@
-import org.codehaus.groovy.grails.commons.ApplicationHolder
-import org.codehaus.groovy.grails.plugins.GrailsPluginUtils
-import org.codehaus.groovy.grails.plugins.PluginManagerHolder
-import org.codehaus.groovy.grails.web.context.ServletContextHolder
+import com.joergrech.kickstartwithbootstrap.CustomDateEditorRegistrar
 
 class KickstartWithBootstrapGrailsPlugin {
     // the plugin version
@@ -18,7 +15,7 @@ class KickstartWithBootstrapGrailsPlugin {
 	def license = "APACHE"
 //	def organization = [ name: "SpringSource", url: "http://www.springsource.org/" ]
 //	def developers = [
-//			[ name: "Jörg Rech", email: "joerg.rech@gmail.com" ]
+//			[ name: "Jï¿½rg Rech", email: "joerg.rech@gmail.com" ]
 //		]
 //	def issueManagement = [ system: "JIRA", url: "http://jira.grails.org/browse/GRAILSPLUGINS" ]
 	def scm = [ url: "https://github.com/joergrech/KickstartWithBootstrap" ]
@@ -36,9 +33,11 @@ class KickstartWithBootstrapGrailsPlugin {
 //        // TODO Implement additions to web.xml (optional), this event occurs before 
 //    }
 //
-//    def doWithSpring = {
-//        // TODO Implement runtime spring config (optional)
-//    }
+	def doWithSpring = {
+		customPropertyEditorRegistrar(CustomDateEditorRegistrar) {
+			grailsApplication = ref("grailsApplication")
+		}
+    }
 //
 //    def doWithDynamicMethods = { ctx ->
 //        // TODO Implement registering dynamic methods to classes (optional)
@@ -53,9 +52,9 @@ class KickstartWithBootstrapGrailsPlugin {
 		def i18nDir 
 		
 		try {
-			if (ApplicationHolder.application.isWarDeployed()) {
+			if (application.isWarDeployed()) {
 				def filePath = "grails-app/i18n"
-				i18nDir = ApplicationHolder.application.parentContext.getResource("${File.separator}WEB-INF${File.separator}${filePath}")?.getFile()
+				i18nDir = application.parentContext.getResource("${File.separator}WEB-INF${File.separator}${filePath}")?.getFile()
 			} else {
 				i18nDir = new File(System.properties['base.dir'] + "/grails-app/i18n")
 			}

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -73,7 +73,7 @@ Similarily, the footer and header can be overwritten (or removed) using sitemesh
 * '''page.footer''' to define the footer by inserting <content tag="page.footer'>...</content> in the view (gsp)
 
 == Developer Notes ==
-Please note that the '''datepicker''' can handle dates after the year 9999 while most databases (e.g., mysql) handle dates with 4-number years. This might result in date that cannot be stored (such as "01/02/20135") and in Exceptions such as "MysqlDataTruncation: Data truncation: Incorrect datetime value: '20135-02-01 00:00:00'" (@see issue #31). If you want to change this behaviour please have a look in the file "src/groovy/CustomDateEditorRegistrar.groovy" and set lenient to false (However, this will also invalidate years before 1000) 
+Please note that the '''datepicker''' can handle dates after the year 9999 while most databases (e.g., mysql) handle dates with 4-number years. This might result in date that cannot be stored (such as "01/02/20135") and in Exceptions such as "MysqlDataTruncation: Data truncation: Incorrect datetime value: '20135-02-01 00:00:00'" (@see issue #31). If you want to change this behaviour please have a look in the file "src/groovy/com/joergrech/kickstartwithbootstrap/CustomDateEditorRegistrar.groovy" and set lenient to false (However, this will also invalidate years before 1000) 
 
 == Terms of Use ==
 

--- a/application.properties
+++ b/application.properties
@@ -2,4 +2,4 @@
 #Sat May 04 09:22:32 CEST 2013
 app.grails.version=2.2.1
 app.name=kickstartWithBootstrapGrailsPlugin
-app.version=0.9.6
+app.version=0.9.7b-csherstan

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -19,7 +19,6 @@ grails.project.dependency.resolution = {
     }
     dependencies {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
-        runtime ('org.lesscss:lesscss:1.3.3')
     }
 	plugins {
         runtime	(":hibernate:$grailsVersion")	{ export = false }		// needed for testing the plugin as an app
@@ -28,7 +27,6 @@ grails.project.dependency.resolution = {
 		
         runtime	(":resources:1.1.6")			{ export = true }		// needed for Bootstrap's less files
 		compile	(":lesscss-resources:1.3.3")	{ 						// needed for Bootstrap's less files
-			excludes "lesscss"											// needed for Bootstrap's 2.3 changes
 			export = true												// see: https://github.com/paulfairless/grails-lesscss-resources/issues/45
 		}		
 

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -27,7 +27,7 @@ grails.project.dependency.resolution = {
 		build	(":release:2.2.0")				{ export = false }		// needed for plugin deployment
 		
         runtime	(":resources:1.1.6")			{ export = true }		// needed for Bootstrap's less files
-		compile	(":lesscss-resources:1.3.1")	{ 						// needed for Bootstrap's less files
+		compile	(":lesscss-resources:1.3.3")	{ 						// needed for Bootstrap's less files
 			excludes "lesscss"											// needed for Bootstrap's 2.3 changes
 			export = true												// see: https://github.com/paulfairless/grails-lesscss-resources/issues/45
 		}		

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -28,6 +28,5 @@ log4j = {
 
 	info	'grails.app.filters'
 }
-grails.config.defaults.locations = [KickstartResources]
 grails.views.default.codec="none" // none, html, base64
 grails.views.gsp.encoding="UTF-8"

--- a/grails-app/conf/KickstartConfig.groovy
+++ b/grails-app/conf/KickstartConfig.groovy
@@ -25,4 +25,3 @@ log4j = {
 
 	info	'grails.app.filters'
 }
-grails.config.defaults.locations = [KickstartResources]

--- a/grails-app/conf/KickstartWithBootstrapPluginResources.groovy
+++ b/grails-app/conf/KickstartWithBootstrapPluginResources.groovy
@@ -20,7 +20,7 @@ modules = {
 			resource url: [dir: 'less/bootstrap',		file: 'responsive.less']
 	  		resource url: "less/dummy.css" // empty css: see https://github.com/paulfairless/grails-lesscss-resources/issues/25
 		}
-		println "| Using LESS files to generating CSS files!"
+		println "| Using LESS files to generate CSS files!"
 	}
 
 	// Utility resources (must be loaded after bootstrap skin resources)

--- a/grails-app/conf/KickstartWithBootstrapPluginResources.groovy
+++ b/grails-app/conf/KickstartWithBootstrapPluginResources.groovy
@@ -1,6 +1,6 @@
 // Settings for the resources and less-css plugins to "compile" less files into css
 
-grails.resources.modules = {
+modules = {
 
 	if ( (grails.resources?.processing?.enabled != [:] && grails.resources.processing.enabled.booleanValue() == false) ) {
 		/* Bootstrap definitions without less (if resource processing is switched off) */

--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -1,4 +1,8 @@
+import com.joergrech.kickstartwithbootstrap.CustomDateEditorRegistrar
+
 // Place your Spring DSL code here
 beans = {
-	customPropertyEditorRegistrar(CustomDateEditorRegistrar)
+	customPropertyEditorRegistrar(CustomDateEditorRegistrar) {
+		grailsApplication = ref("grailsApplication")
+	}
 }

--- a/grails-app/controllers/com/joergrech/kickstartwithbootstrap/HomeController.groovy
+++ b/grails-app/controllers/com/joergrech/kickstartwithbootstrap/HomeController.groovy
@@ -1,3 +1,4 @@
+package com.joergrech.kickstartwithbootstrap
 class HomeController {
 
     def index = {

--- a/grails-app/controllers/com/joergrech/kickstartwithbootstrap/_DemoPageController.groovy
+++ b/grails-app/controllers/com/joergrech/kickstartwithbootstrap/_DemoPageController.groovy
@@ -1,4 +1,5 @@
-package kickstartwithbootstrapgrailsplugin
+package com.joergrech.kickstartwithbootstrap
+
 
 import org.springframework.dao.DataIntegrityViolationException
 

--- a/grails-app/domain/com/joergrech/kickstartwithbootstrap/_DemoPage.groovy
+++ b/grails-app/domain/com/joergrech/kickstartwithbootstrap/_DemoPage.groovy
@@ -1,4 +1,4 @@
-package kickstartwithbootstrapgrailsplugin
+package com.joergrech.kickstartwithbootstrap
 
 /**
  * _DemoPage

--- a/grails-app/taglib/com/joergrech/kickstartwithbootstrap/BootstrapTagLib.groovy
+++ b/grails-app/taglib/com/joergrech/kickstartwithbootstrap/BootstrapTagLib.groovy
@@ -1,4 +1,4 @@
-package kickstart
+package com.joergrech.kickstartwithbootstrap
 
 import java.text.DateFormat
 import java.text.DateFormatSymbols

--- a/grails-app/taglib/kickstart/BootstrapTagLib.groovy
+++ b/grails-app/taglib/kickstart/BootstrapTagLib.groovy
@@ -1,9 +1,10 @@
 package kickstart
 
-import org.springframework.web.servlet.support.RequestContextUtils as RCU;
+import java.text.DateFormat
 import java.text.DateFormatSymbols
-import org.codehaus.groovy.grails.commons.ApplicationHolder
+
 import org.springframework.context.i18n.LocaleContextHolder
+import org.springframework.web.servlet.support.RequestContextUtils as RCU
 
 class BootstrapTagLib {
 	static namespace = "bs"
@@ -241,7 +242,7 @@ class BootstrapTagLib {
 		booleanToAttribute(attrs, 'readonly')
 		
 		// get the localized format for dates. NOTE: datepicker only uses Lowercase syntax and does not understand hours, seconds, etc. (it uses: dd, d, mm, m, yyyy, yy)
-		def messageSource = ApplicationHolder.application.mainContext.getBean('messageSource')
+		def messageSource = grailsAttributes.messageSource
 		String dateFormat = messageSource.getMessage("default.date.datepicker.format",null,null,LocaleContextHolder.locale )
 		if (!dateFormat) { // if date.datepicker.format is not used use date.format but remove characters not used by datepicker
 			dateFormat = messageSource.getMessage("default.date.format",null,'mm/dd/yyyy',LocaleContextHolder.locale )\

--- a/grails-app/views/_DemoPage/_form.gsp
+++ b/grails-app/views/_DemoPage/_form.gsp
@@ -1,4 +1,4 @@
-<%@ page import="kickstartwithbootstrapgrailsplugin._DemoPage" %>
+<%@ page import="com.joergrech.kickstartwithbootstrap._DemoPage" %>
 
 
 
@@ -133,7 +133,7 @@
 			<div class="control-group fieldcontain ${hasErrors(bean: _DemoPageInstance, field: 'myEnum', 'error')} required">
 				<label for="myEnum" class="control-label"><g:message code="_DemoPage.myEnum.label" default="My Enum" /><span class="required-indicator">*</span></label>
 				<div class="controls">
-					<g:select name="myEnum" from="${kickstartwithbootstrapgrailsplugin._DemoPage$Suit?.values()}" keys="${kickstartwithbootstrapgrailsplugin._DemoPage$Suit.values()*.name()}" required="" value="${_DemoPageInstance?.myEnum?.name()}"/>
+					<g:select name="myEnum" from="${com.joergrech.kickstartwithbootstrap._DemoPage$Suit?.values()}" keys="${com.joergrech.kickstartwithbootstrap._DemoPage$Suit.values()*.name()}" required="" value="${_DemoPageInstance?.myEnum?.name()}"/>
 					<span class="help-inline">${hasErrors(bean: _DemoPageInstance, field: 'myEnum', 'error')}</span>
 				</div>
 			</div>

--- a/grails-app/views/_DemoPage/create.gsp
+++ b/grails-app/views/_DemoPage/create.gsp
@@ -1,4 +1,4 @@
-<%@ page import="kickstartwithbootstrapgrailsplugin._DemoPage" %>
+<%@ page import="com.joergrech.kickstartwithbootstrap._DemoPage" %>
 <!doctype html>
 <html>
 

--- a/grails-app/views/_DemoPage/edit.gsp
+++ b/grails-app/views/_DemoPage/edit.gsp
@@ -1,4 +1,4 @@
-<%@ page import="kickstartwithbootstrapgrailsplugin._DemoPage" %>
+<%@ page import="com.joergrech.kickstartwithbootstrap._DemoPage" %>
 <!doctype html>
 <html>
 

--- a/grails-app/views/_DemoPage/list.gsp
+++ b/grails-app/views/_DemoPage/list.gsp
@@ -1,5 +1,5 @@
 
-<%@ page import="kickstartwithbootstrapgrailsplugin._DemoPage" %>
+<%@ page import="com.joergrech.kickstartwithbootstrap._DemoPage" %>
 <!doctype html>
 <html>
 <head>

--- a/grails-app/views/_DemoPage/show.gsp
+++ b/grails-app/views/_DemoPage/show.gsp
@@ -1,5 +1,5 @@
 
-<%@ page import="kickstartwithbootstrapgrailsplugin._DemoPage" %>
+<%@ page import="com.joergrech.kickstartwithbootstrap._DemoPage" %>
 <!doctype html>
 <html>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -11,8 +11,8 @@
     <resource>kickstart.KickstartFilters</resource>
     <resource>spring.resources</resource>
     <resource>HomeController</resource>
-    <resource>kickstartwithbootstrapgrailsplugin._DemoPageController</resource>
-    <resource>kickstartwithbootstrapgrailsplugin._DemoPage</resource>
+    <resource>com.joergrech.kickstartwithbootstrap._DemoPageController</resource>
+    <resource>com.joergrech.kickstartwithbootstrap._DemoPage</resource>
     <resource>kickstart.BootstrapTagLib</resource>
   </resources>
   <repositories>

--- a/scripts/Kickstart.groovy
+++ b/scripts/Kickstart.groovy
@@ -19,7 +19,6 @@ target(kickstart: "Installs the Kickstart scaffolding templates and other files"
 	sourceDir = "${kickstartWithBootstrapPluginDir}/src"
 	targetDir = "${basedir}/grails-app/conf/"
 	copy("${sourceDir}/UrlMappings.groovy",	targetDir,			"URLMappings.groovy",	code)
-	copy("${sourceDir}/resources.groovy",	targetDir+"spring/","resources.groovy",		code)
 	
 	// copy less files into project
 	sourceDir = "${kickstartWithBootstrapPluginDir}/web-app/less"

--- a/scripts/Kickstart.groovy
+++ b/scripts/Kickstart.groovy
@@ -37,18 +37,6 @@ target(kickstart: "Installs the Kickstart scaffolding templates and other files"
 	delete(targetDir+'/index.gsp', "index.gsp in /views", code)
 	delete(targetDir+'/error.gsp', "error.gsp in /views", code)
 
-	// copy resource files into project
-//	sourceDir = "${kickstartWithBootstrapPluginDir}/grails-app/conf/KickstartResources.groovy"
-//	targetDir = "${basedir}/grails-app/conf/"
-//	copy(sourceDir, targetDir, "resource files", code)
-	
-	// inject plugin specific configs into Config.groovy
-	def configFile = new File("${basedir}/grails-app/conf/Config.groovy")
-	if (!configFile.text.contains("KickstartResources")) {
-		configFile.append("\ngrails.config.defaults.locations = [KickstartResources]")
-		event "StatusUpdate", ["... appended include line at the end of Config.groovy!"]
-	}
-
 	event "StatusUpdate", ["Kickstart install ended!"]
 
 }

--- a/src/groovy/com/joergrech/kickstartwithbootstrap/CustomDateEditorRegistrar.groovy
+++ b/src/groovy/com/joergrech/kickstartwithbootstrap/CustomDateEditorRegistrar.groovy
@@ -1,6 +1,6 @@
+package com.joergrech.kickstartwithbootstrap
 import java.text.SimpleDateFormat
 
-import org.codehaus.groovy.grails.commons.ApplicationHolder
 import org.springframework.beans.PropertyEditorRegistrar
 import org.springframework.beans.PropertyEditorRegistry
 import org.springframework.beans.propertyeditors.CustomDateEditor
@@ -9,8 +9,10 @@ import org.codehaus.groovy.grails.web.binding.StructuredDateEditor
 
 public class CustomDateEditorRegistrar implements PropertyEditorRegistrar {
 	
+	def grailsApplication
+	
 	public void registerCustomEditors(PropertyEditorRegistry registry) {
-		def messageSource = ApplicationHolder.application.mainContext.getBean('messageSource')
+		def messageSource = grailsApplication.mainContext.getBean('messageSource')
 		String dateFormat = messageSource.getMessage("default.date.datepicker.format",null,null,LocaleContextHolder.locale )
 		if (!dateFormat) { // if date.datepicker.format is not used use date.format but remove characters not used by datepicker
 			dateFormat = messageSource.getMessage("default.date.format",null,'mm/dd/yyyy',LocaleContextHolder.locale )\

--- a/src/resources.groovy
+++ b/src/resources.groovy
@@ -1,4 +1,0 @@
-// Place your Spring DSL code here
-beans = {
-	customPropertyEditorRegistrar(CustomDateEditorRegistrar)
-}


### PR DESCRIPTION
Dependency injection for customPropertyEditorRegistrar was being handled by directly copying a copy of resources.groovy into the project using the kickstart script. An improved way to do this in a plugin is setup your dependency injection in the doWithSpring closure of your plugin file (KickstartWithBootstrapGrailsPlugin). This way we do not need to copy files in and potentially clobber things in the existing resources.groovy.

In order to do this CustomDateEditorRegistrar could not be in the default package. I refactored all the code to put src files in the com.joergrech.kickstartwithbootstrap package (this is the recommended style of package names). Note that the default, no package, should generally not be used.

Additionally, lesscss-resources has now been upgraded to use less-css:1.3.3 and I have updated BuildConfig.groovy accordingly.

Finally, there were several places where the deprecated ApplicationHolder was being used. I removed those references and replaced them with preferred methods of obtaining the various resources.
