### PR TITLE
Correctly handle controllers RESTful method expectations via _method param

### DIFF
--- a/grails-app/views/_common/modals/_deleteDialog.gsp
+++ b/grails-app/views/_common/modals/_deleteDialog.gsp
@@ -17,6 +17,7 @@ This is the standard dialog that initiates the delete action.
 				<g:form>
 					<button class="btn" data-dismiss="modal" aria-hidden="true"><g:message code="default.button.cancel.label" default="Cancel"/></button>
 					<g:hiddenField name="id" value="${item ? item.id : params.id}" />
+					<g:hiddenField name="_method" value="DELETE" />
 					<span class="button"><g:actionSubmit class="btn btn-danger" action="delete" value="${message(code: 'default.button.delete.label', default: 'Delete')}"/></span>
 				</g:form>
 			</div>

--- a/src/templates/scaffolding/edit.gsp
+++ b/src/templates/scaffolding/edit.gsp
@@ -21,12 +21,12 @@
 		<g:form method="post" class="form-horizontal" role="form" <%= multiPart ? ' enctype="multipart/form-data"' : '' %>>
 			<g:hiddenField name="id" value="\${${propertyName}?.id}" />
 			<g:hiddenField name="version" value="\${${propertyName}?.version}" />
+			<g:hiddenField name="_method" value="PUT" />
 			
 			<g:render template="form"/>
 			
 			<div class="form-actions margin-top-medium">
 				<g:actionSubmit class="btn btn-primary" action="update" value="\${message(code: 'default.button.update.label', default: 'Update')}" />
-				<g:actionSubmit class="btn btn-danger" action="delete" value="\${message(code: 'default.button.delete.label', default: 'Delete')}" onclick="return confirm('\${message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');" />
 	            <button class="btn" type="reset"><g:message code="default.button.reset.label" default="Reset" /></button>
 			</div>
 		</g:form>


### PR DESCRIPTION
HTML forms work via POST, yet controllers expect PUT/DELETE for edit/delete operations.
Fix by adding _method hidden to forms and removing Delete button from edit form.

I _deleteDialog.gsp only line 20 was inserted, dont know why github shows that as 100% change.
