### PR TITLE
Fixed missing appName prefix in form action (using g:form now)

### DIFF
--- a/grails-app/views/_menu/_user.gsp
+++ b/grails-app/views/_menu/_user.gsp
@@ -1,6 +1,6 @@
 <%--<ul class="nav pull-right">--%>
 	<li class="dropdown">
-	
+
 <%--<sec:ifNotLoggedIn>--%>
 
 		<a class="dropdown-toggle" data-toggle="dropdown" href="#">
@@ -11,14 +11,14 @@
 
 		<ul class="dropdown-menu" role="menu">
 			<li class="form-container">
-				<form action="/j_spring_security_check" method="post" accept-charset="UTF-8">
+				<g:form url="j_spring_security_check" method="post" accept-charset="UTF-8">
 <%--				<form action="login" method="post" accept-charset="UTF-8">--%>
 					<input class="form-control" style="margin-bottom: 15px;" type="text"		placeholder="Username" id="username" name="username">
 					<input class="form-control" style="margin-bottom: 15px;" type="password"	placeholder="Password" id="password" name="password">
 					<input style="float: left; margin-right: 10px;" type="checkbox" name="remember-me" id="remember-me" value="1">
 					<label class="string optional" for="user_remember_me"> Remember me</label>
 					<input class="btn btn-primary btn-block" type="submit" id="sign-in" value="Sign In">
-				</form>
+				</g:form>
 			</li>
 			<li class="divider"></li>
 			<li class="button-container">


### PR DESCRIPTION
Hi Joerg,

the appName prefix was eventually missing in the form action. So I changed the tag to use the Grails tag for form.

Cheers
Martin
