### PR TITLE
Update KickstartResources.groovy

### DIFF
--- a/grails-app/conf/KickstartResources.groovy
+++ b/grails-app/conf/KickstartResources.groovy
@@ -4,42 +4,42 @@ modules = {
 
 	/* Bootstrap definitions without less (if resource processing is switched off) */
 	'bootstrap' {
-		resource url: [dir: 'bootstrap/js/tests/vendor',file: 'jquery.js']
-		resource url: [dir: 'bootstrap/dist/js',		file: 'bootstrap.js']
-		resource url: [dir: 'bootstrap/dist/css',		file: 'bootstrap.css']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'bootstrap/js/tests/vendor',file: 'jquery.js']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'bootstrap/dist/js',		file: 'bootstrap.js']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'bootstrap/dist/css',		file: 'bootstrap.css']
 	}
 	log.info "| Using CSS files instead of generating from LESS files! (resource processing was switched off)"
 		
 	/* Utility resources (must be loaded after bootstrap skin resources) */
 	'bootstrap_utils' {
 		dependsOn 'bootstrap'
-		resource url: [dir: 'datepicker/js',			file: 'bootstrap-datepicker.js']
-		resource url: [dir: 'datepicker/css',			file: 'datepicker.css']
-		resource url: [dir: 'kickstart/js',				file: 'kickstart.js']
-		resource url: [dir: 'kickstart/js',				file: 'checkboxes.js']
-		resource url: [dir: 'kickstart/css',			file: 'docs.css']
-		resource url: [dir: 'kickstart/css',			file: 'kickstart.css']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'datepicker/js',			file: 'bootstrap-datepicker.js']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'datepicker/css',			file: 'datepicker.css']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'kickstart/js',				file: 'kickstart.js']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'kickstart/js',				file: 'checkboxes.js']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'kickstart/css',			file: 'docs.css']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'kickstart/css',			file: 'kickstart.css']
 	}
 	
 //	if (!(grails.resources?.processing?.enabled != [:] && grails.resources.processing.enabled.booleanValue() == false) ) {
 	/* Bootstrap definitions with less */
 	'bootstrap_less' {
-		resource url: [dir: 'bootstrap/js/tests/vendor',file: 'jquery.js']
-		resource url: [dir: 'bootstrap/dist/js',		file: 'bootstrap.js']
-		resource url: [dir: 'bootstrap/less',			file: 'bootstrap.less']
-		resource url: [dir: 'kickstart/css',			file: 'dummy.css']			// empty css: see https://github.com/paulfairless/grails-lesscss-resources/issues/25
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'bootstrap/js/tests/vendor',file: 'jquery.js']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'bootstrap/dist/js',		file: 'bootstrap.js']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'bootstrap/less',			file: 'bootstrap.less']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'kickstart/css',			file: 'dummy.css']			// empty css: see https://github.com/paulfairless/grails-lesscss-resources/issues/25
 	}
 	log.info "| Using LESS files to generate CSS files!"
 	
 	/* Utility resources (must be loaded after bootstrap skin resources) */
 	'bootstrap_less_utils' {
 		dependsOn 'bootstrap_less'
-		resource url: [dir: 'datepicker/js',			file: 'bootstrap-datepicker.js']
-		resource url: [dir: 'datepicker/css',			file: 'datepicker.css']
-		resource url: [dir: 'kickstart/js',				file: 'kickstart.js']
-		resource url: [dir: 'kickstart/js',				file: 'checkboxes.js']
-		resource url: [dir: 'kickstart/css',			file: 'docs.css']
-		resource url: [dir: 'kickstart/css',			file: 'kickstart.css']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'datepicker/js',			file: 'bootstrap-datepicker.js']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'datepicker/css',			file: 'datepicker.css']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'kickstart/js',				file: 'kickstart.js']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'kickstart/js',				file: 'checkboxes.js']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'kickstart/css',			file: 'docs.css']
+		resource url: [plugin: 'kickstartWithBootstrap', dir: 'kickstart/css',			file: 'kickstart.css']
 	}
 //	}
 


### PR DESCRIPTION
resources were not found after updating to "resources:1.2.14". this version is needed on grails 2.4.x
